### PR TITLE
Add GenoTEX and CoMAS papers with enhanced descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,16 @@ Chronological order.
 
 ---
 
+#### 9th October 2025
+
+[CoMAS: Co-Evolving Multi-Agent Systems via Interaction Rewards](https://arxiv.org/abs/2510.08529)
+
+- CoMAS (Co-Evolving Multi-Agent Systems via Interaction Rewards): introduces a framework enabling LLM-based agents to co-evolve autonomously through interaction-based rewards, incorporating an LLM-as-judge mechanism and reinforcement learning to optimize agent policies via intrinsic rewards derived from rich inter-agent discussion dynamics.
+- The framework addresses the challenge of collective intelligence emergence without manual annotation by using GPT-4 as an automated judge to score agent contributions based on interaction quality, which then drives policy optimization through a PPO-based RL algorithm.
+- CoMAS demonstrates state-of-the-art performance and scalability in decentralized multi-agent systems, showing that agents can autonomously improve collaborative reasoning through self-generated interaction feedback.
+
+---
+
 #### 7th October 2025
 
 [STRATIFIED GRPO: Handling Structural Heterogeneity in Reinforcement Learning of LLM Search Agents](http://arxiv.org/abs/2510.06214)

--- a/resources/Autonomous_Agents_Research_Papers_2024.md
+++ b/resources/Autonomous_Agents_Research_Papers_2024.md
@@ -3085,7 +3085,9 @@ Uses a depth-first search (DFS) algorithm and a reflection mechanism, implemente
 
 [GenoTEX: A Benchmark for Evaluating LLM-Based Exploration of Gene Expression Data in Alignment with Bioinformaticians](https://arxiv.org/abs/2406.15341)
 
-- GenoAgent: LLM-based genomics data-analysis.  
+- GenoTEX: introduces a benchmark for automated analysis of gene expression data, providing expert-curated code and results for gene-trait association problems, encompassing dataset selection, preprocessing, and statistical analysis.
+- GenoAgent: presents a team of LLM-based agents with specialized roles (Project Manager, Data Engineer, Statistician, Code Reviewer, Domain Expert) that adopt a multi-step programming workflow with flexible self-correction to collaboratively analyze genomic datasets.
+- The benchmark features 1,384 gene-trait association problems, 911 datasets with 152K+ samples, and 238K lines of expert-curated code, demonstrating the potential and challenges of LLM-based methods in scientific discovery.
 
 ---
 


### PR DESCRIPTION
Thank you for maintaining this excellent resource for the community. In this PR, we request to add two relevant papers from our research lab on LLM-based agents:

1. **GenoTEX** (MLCB 2025 Oral): Enhanced the existing entry with comprehensive details about the benchmark for automated gene expression data analysis, including the multi-agent team structure (Project Manager, Data Engineer, Statistician, Code Reviewer, Domain Expert) and key statistics (1,384 problems, 911 datasets, 152K+ samples, 238K lines of expert-curated code).

2. **CoMAS** (October 2025 preprint): Added a new entry describing a framework for co-evolving multi-agent systems via interaction rewards, incorporating an LLM-as-judge mechanism and reinforcement learning to optimize agent policies through intrinsic rewards derived from inter-agent discussion dynamics.

Both entries follow the established format and writing style of the repository, with technically dense yet clear descriptions that maintain consistency with surrounding papers.

Thank you for considering our request.